### PR TITLE
Compatibility with puppet-3.8.3

### DIFF
--- a/manifests/dpm/mysql.pp
+++ b/manifests/dpm/mysql.pp
@@ -1,5 +1,5 @@
 class lcgdm::dpm::mysql ($dbuser, $dbpass, $dbhost) {
-  include 'mysql'
+  include 'mysql::server'
 
   # the packaged db script explicitly creates the db, we don't want that
   file_line { 'dpm mysql commentcreate':

--- a/manifests/ns/mysql.pp
+++ b/manifests/ns/mysql.pp
@@ -1,6 +1,6 @@
 class lcgdm::ns::mysql ($flavor, $dbuser, $dbpass, $dbhost) {
   # management of a mysql db (maybe this could be improved)
-  include 'mysql'
+  include 'mysql:server'
 
   # the packaged db script explicitly creates the db, we don't want that
   file_line { "${flavor} mysql commentcreate":

--- a/manifests/ns/mysql.pp
+++ b/manifests/ns/mysql.pp
@@ -1,6 +1,6 @@
 class lcgdm::ns::mysql ($flavor, $dbuser, $dbpass, $dbhost) {
   # management of a mysql db (maybe this could be improved)
-  include 'mysql:server'
+  include 'mysql::server'
 
   # the packaged db script explicitly creates the db, we don't want that
   file_line { "${flavor} mysql commentcreate":


### PR DESCRIPTION
Hi,

while upgrading to puppet 3.8.3 I've had some problems with the lcgdm and dmlite module. Here are a couple of proposed corrections to these modules. I've made few tests and they seem to work both with 3.8.3 and with 3.4.3 (the version I was using before)

Cheers,
andrea 