### PR TITLE
Changed SELinux label for ${settings::libdir}/augeas/lenses/shift.aug

### DIFF
--- a/manifests/base/config.pp
+++ b/manifests/base/config.pp
@@ -74,7 +74,7 @@ class lcgdm::base::config (
        mode    => '0744',
        seluser => 'system_u',
        selrole => 'object_r',
-       seltype => 'etc_t',
+       seltype => 'puppet_var_lib_t',
        content => template('lcgdm/shift.aug');
   }
 


### PR DESCRIPTION
This was causing refresehe of some dpm services every time puppet was run:
Info: Retrieving pluginfacts
Info: Retrieving plugin
Notice: /File[/var/lib/puppet/lib/augeas/lenses/shift.aug]/seltype: seltype changed 'etc_t' to 'puppet_var_lib_t'
Info: Loading facts
Info: Caching catalog for golias100.farm.particle.cz
Info: Applying configuration version '1486888032'
Notice: /Stage[main]/Roles::Monitoring_nagios/File[/var/log/puppet/]/group: group changed 'puppet' to 'nagios'
Notice: /Stage[main]/Lcgdm::Base::Config/File[/var/lib/puppet/lib/augeas/lenses/shift.aug]/seltype: seltype changed 'puppet_var_lib_t' to 'etc_t'
Info: Class[Lcgdm::Base::Config]: Scheduling refresh of Class[Dmlite::Srm::Service]
Info: Class[Lcgdm::Base::Config]: Scheduling refresh of Class[Dmlite::Dav::Service]
Info: Class[Dmlite::Srm::Service]: Scheduling refresh of Service[srmv2.2]
Notice: /Stage[main]/Dmlite::Srm::Service/Service[srmv2.2]: Triggered 'refresh' from 1 events
Info: Class[Dmlite::Dav::Service]: Scheduling refresh of Service[httpd]
Notice: /Stage[main]/Dmlite::Dav::Service/Service[httpd]: Triggered 'refresh' from 1 events
Notice: Finished catalog run in 73.49 seconds
[root@golias100 ~]# puppet agent -tv
Info: Retrieving pluginfacts
Info: Retrieving plugin
Notice: /File[/var/lib/puppet/lib/augeas/lenses/shift.aug]/seltype: seltype changed 'etc_t' to 'puppet_var_lib_t'
Info: Loading facts
Info: Caching catalog for golias100.farm.particle.cz
Info: Applying configuration version '1486888278'
Notice: /Stage[main]/Roles::Monitoring_nagios/File[/var/log/puppet/]/group: group changed 'puppet' to 'nagios'
Notice: Finished catalog run in 65.19 seconds