### PR TITLE
Remove DPM FTPHEAD in case gridftp_redirect is set to 0

### DIFF
--- a/manifests/shift/unset.pp
+++ b/manifests/shift/unset.pp
@@ -1,0 +1,11 @@
+define lcgdm::shift::unset ($component, $type) {
+  include('lcgdm::shift::config')
+
+  augeas { "shiftunset_${component}-${type}":
+    context => '/files/etc/shift.conf',
+    changes => "rm name[.='$component'][type='$type']",
+    onlyif  => "match name[.='$component'][type='$type'] size != 0",
+    require => [ File["$puppet_vardir/lib/augeas/lenses/shift.aug"],File['/etc/shift.conf']],
+  }
+
+}


### PR DESCRIPTION
In case gridftp_redirect is disabled (changed from enabled state) in headnode configuration, DPM FTPHEAD must be removed from /etc/shift.conf otherwise DPM configuration managed by puppet will not work properly.